### PR TITLE
Update main.adb

### DIFF
--- a/src/main.adb
+++ b/src/main.adb
@@ -113,14 +113,7 @@ procedure Main is
    end Apply;
 
 
-
-
-
-
-
-
    use Queue_Operations;
-
 
 
    Init : Initialize;
@@ -192,7 +185,7 @@ procedure Main is
          loop
             r := decide (new Dequeue'(others => <>));
             exit when r.status = Queue_DeqOk;
-            delay 10.0e-3;
+            delay 50.0e-4;
          end loop;
          Put_Line ("Consumer " & Integer'Image(Main.Process'Pos(Process)) & ": from"
               & Integer'Image (Main.Process'Pos(r.value.owner))
@@ -215,8 +208,6 @@ procedure Main is
    p3 : Producer (Process => 6);
 
 
-
-
 begin
-   Put_Line ("Hello, world!");
+   Put_Line ("Hello from WaitFreeSync Project rev. 1");
 end Main;


### PR DESCRIPTION
Can we decrease delay in producer-consumer queue loop from 10e-3 to 50e-4 w/o loss of performance? Why  500000 in for n in 1 .. 500000 loop ?
Can we utilize smth. like s.first +:= 1; instead of s.first  := s.first + 1; ?